### PR TITLE
feat: add a styled palette of straight track

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -10,7 +10,25 @@
   </head>
   <body>
     <div id="app">
-      <aside class="sidebar">Sidebar</aside>
+      <aside class="sidebar">
+        <div class="palette">
+          <p class="title">Straights</p>
+          <ul class="items">
+            <li>
+              <div class="item">
+                <span class="label">166mm</span>
+                <span class="catno">TT8002</span>
+              </div>
+            </li>
+            <li>
+              <div class="item">
+                <span class="label">332mm</span>
+                <span class="catno">TT8039</span>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </aside>
 
       <main class="main">
         <div class="container">

--- a/src/style.css
+++ b/src/style.css
@@ -27,6 +27,53 @@
   flex: none;
 
   width: 208px;
+
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.palette {
+  border: 2px solid #afeeee;
+  border-radius: 0.375rem;
+
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+
+  .title {
+    background-color: #afeeee;
+    font-size: 1.125rem;
+    line-height: 1.75rem;
+    padding: 0.25rem 0.5rem;
+  }
+
+  .items {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .items > li {
+    border-top: 1px solid #afeeee;
+  }
+
+  .items > li:first-child {
+    border-top: none;
+  }
+
+  .item {
+    padding: 0.25rem;
+
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .item > .catno {
+    font-size: 0.75rem;
+    line-height: 1rem;
+    margin-left: auto;
+  }
 }
 
 .main {


### PR DESCRIPTION
## What?
I've added a styled palette of track to the sidebar #1.

## Why?
We need to add functionality to drag different pieces of code onto the board and this is a first cut on what it should look like.

## How?
Purely HTML and CSS were used - there is no functionality.

## Testing?
Visual - viewed on Chrome and Firefox.

## Screenshots
![image](https://github.com/user-attachments/assets/4418bc29-406d-456d-a1c5-2625be92450d)

## Anything else?
Info was taken from the Hornby TT catalogue.