### PR TITLE
feat: wire up dragging from a palette and dropping on the canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,13 +15,13 @@
           <p class="title">Straights</p>
           <ul class="items">
             <li>
-              <div class="item">
+              <div data-track-id="1" class="item track" draggable="true">
                 <span class="label">166mm</span>
                 <span class="catno">TT8002</span>
               </div>
             </li>
             <li>
-              <div class="item">
+              <div data-track-id="2" class="item track" draggable="true">
                 <span class="label">332mm</span>
                 <span class="catno">TT8039</span>
               </div>

--- a/src/components/board.ts
+++ b/src/components/board.ts
@@ -1,6 +1,13 @@
 let canvas: HTMLCanvasElement;
 
 function setup() {
+  setupCanvas();
+  setupDragHandlers();
+}
+
+// Canvas Setup
+
+function setupCanvas() {
   canvas = document.querySelector<HTMLCanvasElement>("canvas.board")!;
 
   const { width, height } = canvas.parentElement!.getBoundingClientRect();
@@ -10,6 +17,26 @@ function setup() {
 
   canvas.width = width;
   canvas.height = height;
+}
+
+// Drag Event handlers
+
+function setupDragHandlers() {
+  canvas.ondragover = (ev: DragEvent) => {
+    ev.preventDefault();
+
+    ev.dataTransfer!.dropEffect = "copy";
+  };
+
+  canvas.ondrop = (ev: DragEvent) => {
+    const dropped = ev.dataTransfer?.getData("text/plain");
+
+    if (dropped) {
+      const [kind, id] = dropped.split("#");
+
+      console.log(`dropped kind: ${kind} id: ${id}`);
+    }
+  };
 }
 
 export { setup };

--- a/src/components/palette.ts
+++ b/src/components/palette.ts
@@ -1,0 +1,25 @@
+function setup() {
+  const items = document.querySelectorAll<HTMLDivElement>(
+    "div.item.track[draggable='true']",
+  );
+
+  for (const item of items) {
+    item.ondragstart = handleDragStart;
+  }
+}
+
+// Drag Event handlers
+
+function handleDragStart(ev: DragEvent) {
+  const item = ev.currentTarget as HTMLDivElement;
+
+  const trackId = item.dataset.trackId;
+
+  if (trackId) {
+    ev.dataTransfer!.setData("text/plain", `track#${trackId}`);
+
+    console.log(`dragging track: ${trackId}`);
+  }
+}
+
+export { setup };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,9 @@
 import * as board from "./components/board";
+import * as palette from "./components/palette";
 
 window.onload = setup;
 
 function setup() {
   board.setup();
+  palette.setup();
 }


### PR DESCRIPTION
## What?
I've wired up dragging track from a palette onto a canvas.

## Why?
There are certain pieces that need to be in place to follow the HTML Drag and Drop API. 

## How?
- set draggable attribute in html + dataset-track-id value identifying individual items.
- wired up ondragstart handler in palette
- wired up ondragover and ondrop canvas event handlers.

## Testing?
Visual and consoling - this isn't a React app.

## Screenshots
Item being dragged...
![image](https://github.com/user-attachments/assets/a77aebb6-775a-4eb3-963a-15c5cd92f9ad)

confirmation in log
![image](https://github.com/user-attachments/assets/842afc93-b694-49be-a92d-7acd172d57a7)

