### PR TITLE
feat: implement a 'Straight' track type with functionality to be rend…

### DIFF
--- a/src/components/board.ts
+++ b/src/components/board.ts
@@ -1,14 +1,26 @@
+import { Straight } from "../track/straight";
+
 let canvas: HTMLCanvasElement;
+let ctx: CanvasRenderingContext2D;
 
 function setup() {
   setupCanvas();
   setupDragHandlers();
+
+  drawStraight();
+}
+
+function drawStraight() {
+  const straight = new Straight("ZTT001", 166);
+
+  straight.render(ctx);
 }
 
 // Canvas Setup
 
 function setupCanvas() {
   canvas = document.querySelector<HTMLCanvasElement>("canvas.board")!;
+  ctx = canvas.getContext("2d")!;
 
   const { width, height } = canvas.parentElement!.getBoundingClientRect();
 

--- a/src/track/straight.test.ts
+++ b/src/track/straight.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "vitest";
+import { Straight } from "./straight";
+
+describe("Straight", () => {
+  test("should have catno and length", () => {
+    const straight = new Straight("ZZ1001", 166);
+
+    expect(straight).not.toBeUndefined();
+    expect(straight.catno).toBe("ZZ1001");
+    expect(straight.length).toBe(166);
+  });
+});

--- a/src/track/straight.ts
+++ b/src/track/straight.ts
@@ -1,0 +1,30 @@
+const SLEEPER_LENGTH = 22;
+
+class Straight {
+  catno: string;
+  length: number;
+
+  constructor(catno: string, length: number) {
+    this.catno = catno;
+    this.length = length;
+  }
+
+  render(ctx: CanvasRenderingContext2D) {
+    ctx.fillStyle = "#0000ff";
+    ctx.rect(100, 100, this.length, SLEEPER_LENGTH);
+    ctx.fill();
+
+    ctx.fillStyle = "#ffffff";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.font = "18px arial";
+    ctx.fillText(
+      this.catno,
+      100 + this.length / 2,
+      100 + SLEEPER_LENGTH / 2,
+      this.length,
+    );
+  }
+}
+
+export { Straight };


### PR DESCRIPTION
## What? 
Implemented  a "Straight" class representing a straight piece of track that has a render method to draw our track on the canvas.

## Why? 
Wanted a proven class prior to dealing with lookup and drag/dropping functionality.

## How?
Created a "Straight" class with a render() method, and the board component instantiates an instance with catalogue number and length.

## Testing?
A test was written for the Straight constructor but not the render() method.

## Screenshots
Here's a pic of the track being rendered with the supplied text.
![image](https://github.com/user-attachments/assets/ca3e71e1-1d0f-4544-9dd3-22e394723eac)
