### PR TITLE
feat: add spec for standard and double straights

### DIFF
--- a/src/components/board.ts
+++ b/src/components/board.ts
@@ -1,4 +1,4 @@
-import { Straight } from "../track/straight";
+import { Straight, StraightSpec } from "../track/straight";
 
 let canvas: HTMLCanvasElement;
 let ctx: CanvasRenderingContext2D;
@@ -11,7 +11,14 @@ function setup() {
 }
 
 function drawStraight() {
-  const straight = new Straight("ZTT001", 166);
+  const spec: StraightSpec = {
+    id: "1",
+    catno: "TT8002",
+    label: "166mm",
+    length: 166,
+  };
+
+  const straight = new Straight(spec);
 
   straight.render(ctx);
 }

--- a/src/components/board.ts
+++ b/src/components/board.ts
@@ -11,16 +11,29 @@ function setup() {
 }
 
 function drawStraight() {
-  const spec: StraightSpec = {
-    id: "1",
-    catno: "TT8002",
-    label: "166mm",
-    length: 166,
-  };
+  const specs: StraightSpec[] = [
+    {
+      id: "1",
+      catno: "TT8002",
+      label: "166mm",
+      length: 166,
+    },
+    {
+      id: "2",
+      catno: "TT8039",
+      label: "332mm",
+      length: 332,
+    },
+  ];
 
-  const straight = new Straight(spec);
+  const tt8002 = new Straight(specs[0]);
+  tt8002.setPosition(216, 50);
 
-  straight.render(ctx);
+  const tt8039 = new Straight(specs[1]);
+  tt8039.setPosition(50, 100);
+
+  tt8002.render(ctx);
+  tt8039.render(ctx);
 }
 
 // Canvas Setup

--- a/src/track/straight.test.ts
+++ b/src/track/straight.test.ts
@@ -16,4 +16,20 @@ describe("Straight", () => {
     expect(straight.spec.catno).toBe("TT8002");
     expect(straight.spec.length).toBe(166);
   });
+
+  test("should have default position", () => {
+    const straight = new Straight(spec);
+
+    expect(straight.x).toBe(0);
+    expect(straight.y).toBe(0);
+  });
+
+  test("should have given position", () => {
+    const straight = new Straight(spec);
+
+    straight.setPosition(100, 200);
+
+    expect(straight.x).toBe(100);
+    expect(straight.y).toBe(200);
+  });
 });

--- a/src/track/straight.test.ts
+++ b/src/track/straight.test.ts
@@ -1,12 +1,19 @@
 import { describe, expect, test } from "vitest";
-import { Straight } from "./straight";
+import { Straight, StraightSpec } from "./straight";
+
+const spec: StraightSpec = {
+  id: "1",
+  catno: "TT8002",
+  label: "166mm",
+  length: 166,
+};
 
 describe("Straight", () => {
   test("should have catno and length", () => {
-    const straight = new Straight("ZZ1001", 166);
+    const straight = new Straight(spec);
 
     expect(straight).not.toBeUndefined();
-    expect(straight.catno).toBe("ZZ1001");
-    expect(straight.length).toBe(166);
+    expect(straight.spec.catno).toBe("TT8002");
+    expect(straight.spec.length).toBe(166);
   });
 });

--- a/src/track/straight.ts
+++ b/src/track/straight.ts
@@ -1,30 +1,32 @@
 const SLEEPER_LENGTH = 22;
 
-class Straight {
+type StraightSpec = {
+  id: string;
   catno: string;
+  label: string;
   length: number;
+};
 
-  constructor(catno: string, length: number) {
-    this.catno = catno;
-    this.length = length;
+class Straight {
+  spec: StraightSpec;
+
+  constructor(spec: StraightSpec) {
+    this.spec = spec;
   }
 
   render(ctx: CanvasRenderingContext2D) {
+    const { catno, length } = this.spec;
+
     ctx.fillStyle = "#0000ff";
-    ctx.rect(100, 100, this.length, SLEEPER_LENGTH);
+    ctx.rect(100, 100, length, SLEEPER_LENGTH);
     ctx.fill();
 
     ctx.fillStyle = "#ffffff";
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
     ctx.font = "18px arial";
-    ctx.fillText(
-      this.catno,
-      100 + this.length / 2,
-      100 + SLEEPER_LENGTH / 2,
-      this.length,
-    );
+    ctx.fillText(catno, 100 + length / 2, 100 + SLEEPER_LENGTH / 2, length);
   }
 }
 
-export { Straight };
+export { Straight, type StraightSpec };

--- a/src/track/straight.ts
+++ b/src/track/straight.ts
@@ -9,23 +9,36 @@ type StraightSpec = {
 
 class Straight {
   spec: StraightSpec;
+  x = 0;
+  y = 0;
 
   constructor(spec: StraightSpec) {
     this.spec = spec;
   }
 
+  setPosition(x: number, y: number) {
+    this.x = x;
+    this.y = y;
+  }
+
   render(ctx: CanvasRenderingContext2D) {
     const { catno, length } = this.spec;
 
+    ctx.beginPath();
     ctx.fillStyle = "#0000ff";
-    ctx.rect(100, 100, length, SLEEPER_LENGTH);
+    ctx.rect(this.x, this.y, length, SLEEPER_LENGTH);
     ctx.fill();
 
     ctx.fillStyle = "#ffffff";
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
     ctx.font = "18px arial";
-    ctx.fillText(catno, 100 + length / 2, 100 + SLEEPER_LENGTH / 2, length);
+    ctx.fillText(
+      catno,
+      this.x + length / 2,
+      this.y + SLEEPER_LENGTH / 2,
+      length,
+    );
   }
 }
 


### PR DESCRIPTION
## What?
Created specs for TT8002 and TT3039 and added a setPosition() method to the  Straight class.

## Why?
PR proves a straight will be rendered according to its spec.
The setPosition() method was implemented to get a usable screenshot.

## How?
Hard coded a spec array in the board component and set the position of the two instances.

# Testing?
Added a test for the setPosition() method.
Also added a ctx.beginPath() call in Straight.render() to ensure the correct fillStyles are used.

# Screenshots
The two instances rendered on the canvas - the standard track is offset by 166 pixels to illustrate their relative  lengths.
![image](https://github.com/user-attachments/assets/b894ffb7-d448-491c-93da-41acd2a4becd)

## Anything else?
This PR closes #10 
