### PR TITLE
feat: implement track lookup and creation

### DIFF
--- a/src/components/board.ts
+++ b/src/components/board.ts
@@ -1,39 +1,34 @@
-import { Straight, StraightSpec } from "../track/straight";
+import { TRACK_CATALOG } from "../constants";
+import { TrackManager } from "../track/track_manager";
 
 let canvas: HTMLCanvasElement;
 let ctx: CanvasRenderingContext2D;
+
+let trackManager: TrackManager;
 
 function setup() {
   setupCanvas();
   setupDragHandlers();
 
+  trackManager = new TrackManager(TRACK_CATALOG);
+
   drawStraight();
 }
 
 function drawStraight() {
-  const specs: StraightSpec[] = [
-    {
-      id: "1",
-      catno: "TT8002",
-      label: "166mm",
-      length: 166,
-    },
-    {
-      id: "2",
-      catno: "TT8039",
-      label: "332mm",
-      length: 332,
-    },
-  ];
+  const tt8002 = trackManager.add("1");
 
-  const tt8002 = new Straight(specs[0]);
-  tt8002.setPosition(216, 50);
+  if (tt8002 !== undefined) {
+    tt8002.setPosition(216, 50);
+    tt8002.render(ctx);
+  }
 
-  const tt8039 = new Straight(specs[1]);
-  tt8039.setPosition(50, 100);
+  const tt8039 = trackManager.add("2");
 
-  tt8002.render(ctx);
-  tt8039.render(ctx);
+  if (tt8039 !== undefined) {
+    tt8039.setPosition(50, 100);
+    tt8039.render(ctx);
+  }
 }
 
 // Canvas Setup

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,18 @@
+import { StraightSpec } from "./track/straight";
+
+const TRACK_CATALOG: StraightSpec[] = [
+  {
+    id: "1",
+    catno: "TT8002",
+    label: "166mm",
+    length: 166,
+  },
+  {
+    id: "2",
+    catno: "TT8039",
+    label: "332mm",
+    length: 332,
+  },
+];
+
+export { TRACK_CATALOG };

--- a/src/track/track_manager.test.ts
+++ b/src/track/track_manager.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { StraightSpec } from "./straight";
+import { TrackManager } from "./track_manager";
+
+const catalog: StraightSpec[] = [
+  {
+    id: "1",
+    catno: "TT8002",
+    label: "166mm",
+    length: 166,
+  },
+  {
+    id: "2",
+    catno: "TT8039",
+    label: "332mm",
+    length: 332,
+  },
+];
+
+let manager: TrackManager;
+
+beforeEach(() => {
+  manager = new TrackManager(catalog);
+});
+
+describe("TrackManager", () => {
+  test("should have zero specs", () => {
+    const trackManager = new TrackManager([]);
+
+    expect(trackManager).not.toBeUndefined();
+    expect(trackManager.catalog).toHaveLength(0);
+  });
+
+  test("should have two track specs", () => {
+    expect(manager.catalog).toHaveLength(2);
+  });
+
+  test("should hold zero pieces of track", () => {
+    expect(manager.tracks).toHaveLength(0);
+  });
+
+  test("should hold one piece of track", () => {
+    manager.add("1");
+
+    expect(manager.tracks).toHaveLength(1);
+  });
+
+  test("should hold no unknown pieces of track", () => {
+    manager.add("abc");
+
+    expect(manager.tracks).toHaveLength(0);
+  });
+
+  test("should not return unknown track", () => {
+    const track = manager.add("xyz");
+
+    expect(track).toBeUndefined();
+  });
+
+  test("should hold a single double length straight", () => {
+    manager.add("2");
+
+    expect(manager.tracks[0].spec.catno).toBe("TT8039");
+  });
+
+  test("should return a piece of track", () => {
+    const track = manager.add("1");
+
+    expect(track?.spec.catno).toBe("TT8002");
+  });
+});

--- a/src/track/track_manager.ts
+++ b/src/track/track_manager.ts
@@ -1,0 +1,27 @@
+import { Straight, StraightSpec } from "./straight";
+
+class TrackManager {
+  readonly catalog: StraightSpec[] = [];
+  readonly tracks: Straight[] = [];
+
+  constructor(catalog: StraightSpec[]) {
+    this.catalog = catalog;
+  }
+
+  add(productId: string) {
+    const spec = this.catalog.find((p) => p.id === productId);
+
+    if (spec === undefined) {
+      console.log(`unknown track product id: "${productId}"`);
+      return;
+    }
+
+    const track = new Straight(spec);
+
+    this.tracks.push(track);
+
+    return track;
+  }
+}
+
+export { TrackManager };


### PR DESCRIPTION
## What? 
I've wrapped track lookup and creation with tests and closes #11 .

## Why?
Moves looking up track details to one well defined place.

## How?
I've implemented a TrackManager class and declared the track catalogue array as a constant.

## Testing?
These are included in the track_manager.test.ts file.

## Screenshots (optional)
Same results as test shots from previous PR (#18).
![image](https://github.com/user-attachments/assets/eea96d3f-a11d-47a4-b95d-1f40655f4319)

## Anything else?
n/a
