### PR TITLE
Drag n Drop from Palette

### DIFF
--- a/src/components/board.ts
+++ b/src/components/board.ts
@@ -49,9 +49,7 @@ function setupDragHandlers() {
     const dropped = ev.dataTransfer?.getData("text/plain");
 
     if (dropped) {
-      const [kind, id] = dropped.split("#");
-
-      console.log(`dropped ${kind} id: ${id} @ (${ev.offsetX}, ${ev.offsetY})`);
+      const [_, id] = dropped.split("#");
 
       trackManager.add(id, { x: ev.offsetX, y: ev.offsetY });
 

--- a/src/components/board.ts
+++ b/src/components/board.ts
@@ -12,22 +12,12 @@ function setup() {
 
   trackManager = new TrackManager(TRACK_CATALOG);
 
-  drawStraight();
+  draw();
 }
 
-function drawStraight() {
-  const tt8002 = trackManager.add("1");
-
-  if (tt8002 !== undefined) {
-    tt8002.setPosition(216, 50);
-    tt8002.render(ctx);
-  }
-
-  const tt8039 = trackManager.add("2");
-
-  if (tt8039 !== undefined) {
-    tt8039.setPosition(50, 100);
-    tt8039.render(ctx);
+function draw() {
+  for (const track of trackManager.tracks) {
+    track.render(ctx);
   }
 }
 
@@ -61,7 +51,11 @@ function setupDragHandlers() {
     if (dropped) {
       const [kind, id] = dropped.split("#");
 
-      console.log(`dropped kind: ${kind} id: ${id}`);
+      console.log(`dropped ${kind} id: ${id} @ (${ev.offsetX}, ${ev.offsetY})`);
+
+      trackManager.add(id, { x: ev.offsetX, y: ev.offsetY });
+
+      draw();
     }
   };
 }

--- a/src/components/palette.ts
+++ b/src/components/palette.ts
@@ -17,8 +17,6 @@ function handleDragStart(ev: DragEvent) {
 
   if (trackId) {
     ev.dataTransfer!.setData("text/plain", `track#${trackId}`);
-
-    console.log(`dragging track: ${trackId}`);
   }
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,7 @@
 import { StraightSpec } from "./track/straight";
 
+const SLEEPER_LENGTH = 22;
+
 const TRACK_CATALOG: StraightSpec[] = [
   {
     id: "1",
@@ -15,4 +17,4 @@ const TRACK_CATALOG: StraightSpec[] = [
   },
 ];
 
-export { TRACK_CATALOG };
+export { SLEEPER_LENGTH, TRACK_CATALOG };

--- a/src/lib/coords.ts
+++ b/src/lib/coords.ts
@@ -1,0 +1,3 @@
+type Coords = { x: number; y: number };
+
+export { type Coords };

--- a/src/track/straight.test.ts
+++ b/src/track/straight.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { SLEEPER_LENGTH } from "../constants";
 import { Straight, StraightSpec } from "./straight";
 
 const spec: StraightSpec = {
@@ -31,5 +32,14 @@ describe("Straight", () => {
 
     expect(straight.x).toBe(100);
     expect(straight.y).toBe(200);
+  });
+
+  test("should have offset in centre", () => {
+    const straight = new Straight(spec);
+
+    const offset = straight.getDropOffset();
+
+    expect(offset.x).toBe(spec.length / 2);
+    expect(offset.y).toBe(SLEEPER_LENGTH / 2);
   });
 });

--- a/src/track/straight.test.ts
+++ b/src/track/straight.test.ts
@@ -13,8 +13,8 @@ describe("Straight", () => {
     const straight = new Straight(spec);
 
     expect(straight).not.toBeUndefined();
-    expect(straight.spec.catno).toBe("TT8002");
-    expect(straight.spec.length).toBe(166);
+    expect(straight.catno).toBe("TT8002");
+    expect(straight.length).toBe(166);
   });
 
   test("should have default position", () => {

--- a/src/track/straight.test.ts
+++ b/src/track/straight.test.ts
@@ -27,7 +27,7 @@ describe("Straight", () => {
   test("should have given position", () => {
     const straight = new Straight(spec);
 
-    straight.setPosition(100, 200);
+    straight.setPosition({ x: 100, y: 200 });
 
     expect(straight.x).toBe(100);
     expect(straight.y).toBe(200);

--- a/src/track/straight.ts
+++ b/src/track/straight.ts
@@ -10,12 +10,18 @@ type StraightSpec = {
 };
 
 class Straight {
-  spec: StraightSpec;
+  trackId: string;
+  catno: string;
+  label: string;
+  length: number;
   x = 0;
   y = 0;
 
   constructor(spec: StraightSpec) {
-    this.spec = spec;
+    this.trackId = spec.id;
+    this.catno = spec.catno;
+    this.label = spec.label;
+    this.length = spec.length;
   }
 
   setPosition(coords: Coords) {
@@ -24,11 +30,9 @@ class Straight {
   }
 
   render(ctx: CanvasRenderingContext2D) {
-    const { catno, length } = this.spec;
-
     ctx.beginPath();
     ctx.fillStyle = "#0000ff";
-    ctx.rect(this.x, this.y, length, SLEEPER_LENGTH);
+    ctx.rect(this.x, this.y, this.length, SLEEPER_LENGTH);
     ctx.fill();
 
     ctx.fillStyle = "#ffffff";
@@ -36,10 +40,10 @@ class Straight {
     ctx.textBaseline = "middle";
     ctx.font = "18px arial";
     ctx.fillText(
-      catno,
-      this.x + length / 2,
+      this.catno,
+      this.x + this.length / 2,
       this.y + SLEEPER_LENGTH / 2,
-      length,
+      this.length,
     );
   }
 }

--- a/src/track/straight.ts
+++ b/src/track/straight.ts
@@ -1,6 +1,5 @@
 import { Coords } from "../lib/coords";
-
-const SLEEPER_LENGTH = 22;
+import { SLEEPER_LENGTH } from "../constants";
 
 type StraightSpec = {
   id: string;
@@ -22,6 +21,13 @@ class Straight {
     this.catno = spec.catno;
     this.label = spec.label;
     this.length = spec.length;
+  }
+
+  getDropOffset() {
+    return {
+      x: this.length / 2,
+      y: SLEEPER_LENGTH / 2,
+    } as Coords;
   }
 
   setPosition(coords: Coords) {

--- a/src/track/straight.ts
+++ b/src/track/straight.ts
@@ -1,3 +1,5 @@
+import { Coords } from "../lib/coords";
+
 const SLEEPER_LENGTH = 22;
 
 type StraightSpec = {
@@ -16,9 +18,9 @@ class Straight {
     this.spec = spec;
   }
 
-  setPosition(x: number, y: number) {
-    this.x = x;
-    this.y = y;
+  setPosition(coords: Coords) {
+    this.x = coords.x;
+    this.y = coords.y;
   }
 
   render(ctx: CanvasRenderingContext2D) {

--- a/src/track/track_manager.test.ts
+++ b/src/track/track_manager.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test } from "vitest";
 import { StraightSpec } from "./straight";
 import { TrackManager } from "./track_manager";
+import { Coords } from "../lib/coords";
 
 const catalog: StraightSpec[] = [
   {
@@ -16,6 +17,8 @@ const catalog: StraightSpec[] = [
     length: 332,
   },
 ];
+
+const position: Coords = { x: 100, y: 200 };
 
 let manager: TrackManager;
 
@@ -38,34 +41,45 @@ describe("TrackManager", () => {
   test("should hold zero pieces of track", () => {
     expect(manager.tracks).toHaveLength(0);
   });
+});
 
+describe("add new track", () => {
   test("should hold one piece of track", () => {
-    manager.add("1");
+    manager.add("1", position);
 
     expect(manager.tracks).toHaveLength(1);
   });
 
   test("should hold no unknown pieces of track", () => {
-    manager.add("abc");
+    manager.add("abc", position);
 
     expect(manager.tracks).toHaveLength(0);
   });
 
   test("should not return unknown track", () => {
-    const track = manager.add("xyz");
+    const track = manager.add("xyz", position);
 
     expect(track).toBeUndefined();
   });
 
   test("should hold a single double length straight", () => {
-    manager.add("2");
+    manager.add("2", position);
 
     expect(manager.tracks[0].spec.catno).toBe("TT8039");
   });
 
   test("should return a piece of track", () => {
-    const track = manager.add("1");
+    const track = manager.add("1", position);
 
     expect(track?.spec.catno).toBe("TT8002");
+  });
+
+  test("should contain track positioned at (150, 250)", () => {
+    manager.add("1", { x: 150, y: 250 });
+
+    const track = manager.tracks[0];
+
+    expect(track.x).toBe(150);
+    expect(track.y).toBe(250);
   });
 });

--- a/src/track/track_manager.test.ts
+++ b/src/track/track_manager.test.ts
@@ -68,12 +68,6 @@ describe("add new track", () => {
     expect(manager.tracks[0].catno).toBe("TT8039");
   });
 
-  test("should return a piece of track", () => {
-    const track = manager.add("1", position);
-
-    expect(track?.catno).toBe("TT8002");
-  });
-
   test("should contain track positioned at (150, 250)", () => {
     manager.add("1", { x: 150, y: 250 });
 

--- a/src/track/track_manager.test.ts
+++ b/src/track/track_manager.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test } from "vitest";
 import { StraightSpec } from "./straight";
 import { TrackManager } from "./track_manager";
 import { Coords } from "../lib/coords";
+import { SLEEPER_LENGTH } from "../constants";
 
 const catalog: StraightSpec[] = [
   {
@@ -68,12 +69,14 @@ describe("add new track", () => {
     expect(manager.tracks[0].catno).toBe("TT8039");
   });
 
-  test("should contain track positioned at (150, 250)", () => {
+  test("should contain track positioned offset from (150, 250)", () => {
+    const expectedX = 150 - 166 / 2;
+    const expectedY = 250 - SLEEPER_LENGTH / 2;
     manager.add("1", { x: 150, y: 250 });
 
     const track = manager.tracks[0];
 
-    expect(track.x).toBe(150);
-    expect(track.y).toBe(250);
+    expect(track.x).toBe(expectedX);
+    expect(track.y).toBe(expectedY);
   });
 });

--- a/src/track/track_manager.test.ts
+++ b/src/track/track_manager.test.ts
@@ -65,13 +65,13 @@ describe("add new track", () => {
   test("should hold a single double length straight", () => {
     manager.add("2", position);
 
-    expect(manager.tracks[0].spec.catno).toBe("TT8039");
+    expect(manager.tracks[0].catno).toBe("TT8039");
   });
 
   test("should return a piece of track", () => {
     const track = manager.add("1", position);
 
-    expect(track?.spec.catno).toBe("TT8002");
+    expect(track?.catno).toBe("TT8002");
   });
 
   test("should contain track positioned at (150, 250)", () => {

--- a/src/track/track_manager.ts
+++ b/src/track/track_manager.ts
@@ -1,3 +1,4 @@
+import { Coords } from "../lib/coords";
 import { Straight, StraightSpec } from "./straight";
 
 class TrackManager {
@@ -8,7 +9,7 @@ class TrackManager {
     this.catalog = catalog;
   }
 
-  add(productId: string) {
+  add(productId: string, coords: Coords) {
     const spec = this.catalog.find((p) => p.id === productId);
 
     if (spec === undefined) {
@@ -17,6 +18,7 @@ class TrackManager {
     }
 
     const track = new Straight(spec);
+    track.setPosition(coords);
 
     this.tracks.push(track);
 

--- a/src/track/track_manager.ts
+++ b/src/track/track_manager.ts
@@ -17,12 +17,16 @@ class TrackManager {
       return;
     }
 
+    console.log(`adding ${productId} @ (${coords.x}, ${coords.y})`);
+
     const track = new Straight(spec);
     track.setPosition(coords);
 
-    this.tracks.push(track);
+    console.log(
+      `added ${track.trackId}:${track.catno} @ (${track.x}, ${track.y})`,
+    );
 
-    return track;
+    this.tracks.push(track);
   }
 }
 

--- a/src/track/track_manager.ts
+++ b/src/track/track_manager.ts
@@ -13,18 +13,13 @@ class TrackManager {
     const spec = this.catalog.find((p) => p.id === productId);
 
     if (spec === undefined) {
-      console.log(`unknown track product id: "${productId}"`);
       return;
     }
 
-    console.log(`adding ${productId} @ (${coords.x}, ${coords.y})`);
-
     const track = new Straight(spec);
-    track.setPosition(coords);
-
-    console.log(
-      `added ${track.trackId}:${track.catno} @ (${track.x}, ${track.y})`,
-    );
+    const offset = track.getDropOffset();
+    const position = { x: coords.x - offset.x, y: coords.y - offset.y };
+    track.setPosition(position);
 
     this.tracks.push(track);
   }


### PR DESCRIPTION
## What?
I've tied all the pieces together to enable track dragged from a palette to be drawn on the canvas.  This closes issue #4.

## Why?
This completes the first feature of the app.

## How?
Added code to the canvas.ondrop event handler in boards.ts to add track for the dragged track "id".
Implemented the getDropOffset() method in the Straights class to allow dropped track to be centered on the mouse drop coordinates (otherwise the track appears to be dropped to the right of the mouse cursor position).

## Testing?
Updated tests included for both the Straight and TrackManager classes.

## Screenshots (optional)
A shot of the results of dragging both types of track onto the canvas.
![image](https://github.com/user-attachments/assets/d8527497-386e-4e10-b127-d1e0ff5242a3)


## Anything else?
n/a