### PR TITLE
Move track around the board

### DIFF
--- a/src/components/board.ts
+++ b/src/components/board.ts
@@ -4,21 +4,29 @@ import { TrackManager } from "../track/track_manager";
 let canvas: HTMLCanvasElement;
 let ctx: CanvasRenderingContext2D;
 
+let viewWidth: number;
+let viewHeight: number;
+
 let trackManager: TrackManager;
 
 function setup() {
   setupCanvas();
   setupDragHandlers();
+  setupMouseHandlers();
 
   trackManager = new TrackManager(TRACK_CATALOG);
 
-  draw();
+  requestAnimationFrame(draw);
 }
 
 function draw() {
+  ctx.clearRect(0, 0, viewWidth, viewHeight);
+
   for (const track of trackManager.tracks) {
     track.render(ctx);
   }
+
+  requestAnimationFrame(draw);
 }
 
 // Canvas Setup
@@ -28,6 +36,9 @@ function setupCanvas() {
   ctx = canvas.getContext("2d")!;
 
   const { width, height } = canvas.parentElement!.getBoundingClientRect();
+
+  viewWidth = width;
+  viewHeight = height;
 
   canvas.style.width = `${width}px`;
   canvas.style.height = `${height}px`;
@@ -54,6 +65,32 @@ function setupDragHandlers() {
       trackManager.add(id, { x: ev.offsetX, y: ev.offsetY });
 
       draw();
+    }
+  };
+}
+
+// Mouse Event handlers
+
+function setupMouseHandlers() {
+  canvas.onmousedown = (ev: MouseEvent) => {
+    const mouseXY = { x: ev.offsetX, y: ev.offsetY };
+
+    for (const track of trackManager.tracks) {
+      track.onMouseDown(mouseXY);
+    }
+  };
+
+  canvas.onmouseup = () => {
+    for (const track of trackManager.tracks) {
+      track.onMouseUp();
+    }
+  };
+
+  canvas.onmousemove = (ev: MouseEvent) => {
+    const mouseXY = { x: ev.offsetX, y: ev.offsetY };
+
+    for (const track of trackManager.tracks) {
+      track.dragGrabbed(mouseXY);
     }
   };
 }

--- a/src/track/move_track.test.ts
+++ b/src/track/move_track.test.ts
@@ -56,7 +56,7 @@ describe("Move track around board", () => {
     expect(straight.y).toBe(300);
   });
 
-  test("should register mouse up", () => {
+  test("should not move after mouse up", () => {
     straight.onMouseDown({ x: 110, y: 110 });
     straight.onMouseUp();
 

--- a/src/track/move_track.test.ts
+++ b/src/track/move_track.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { Straight, StraightSpec } from "./straight";
+
+const spec: StraightSpec = {
+  id: "99",
+  catno: "ZZZ200",
+  label: "200mm",
+  length: 200,
+};
+
+let straight: Straight;
+
+beforeEach(() => {
+  straight = new Straight(spec);
+  straight.setPosition({ x: 100, y: 100 });
+});
+
+describe("Move track around board", () => {
+  test("should not be grabbed", () => {
+    expect(straight.isGrabbed()).toBe(false);
+  });
+
+  test("should not be grabbed", () => {
+    straight.onMouseDown({ x: 10, y: 10 });
+
+    expect(straight.isGrabbed()).toBe(false);
+  });
+
+  test("should be grabbed", () => {
+    straight.onMouseDown({ x: 110, y: 110 });
+
+    expect(straight.isGrabbed()).toBe(true);
+  });
+
+  test("should not be dragged", () => {
+    straight.onMouseDown({ x: 10, y: 10 });
+    straight.dragGrabbed({ x: 210, y: 310 });
+
+    expect(straight.x).toBe(100);
+    expect(straight.y).toBe(100);
+  });
+
+  test("should be dragged", () => {
+    straight.onMouseDown({ x: 110, y: 110 });
+    straight.dragGrabbed({ x: 210, y: 310 });
+
+    expect(straight.x).not.toBe(100);
+    expect(straight.y).not.toBe(100);
+  });
+
+  test("should be offset by mousedown position", () => {
+    straight.onMouseDown({ x: 110, y: 110 });
+    straight.dragGrabbed({ x: 210, y: 310 });
+
+    expect(straight.x).toBe(200);
+    expect(straight.y).toBe(300);
+  });
+
+  test("should register mouse up", () => {
+    straight.onMouseDown({ x: 110, y: 110 });
+    straight.onMouseUp();
+
+    straight.dragGrabbed({ x: 210, y: 310 });
+
+    expect(straight.x).toBe(100);
+    expect(straight.y).toBe(100);
+  });
+});

--- a/src/track/straight.test.ts
+++ b/src/track/straight.test.ts
@@ -42,4 +42,42 @@ describe("Straight", () => {
     expect(offset.x).toBe(spec.length / 2);
     expect(offset.y).toBe(SLEEPER_LENGTH / 2);
   });
+
+  test("should not encompass outside coords", () => {
+    const straight = new Straight(spec);
+    straight.setPosition({ x: 100, y: 100 });
+
+    const above = { x: 150, y: 99 };
+    const below = { x: 150, y: 123 };
+    const left = { x: 99, y: 106 };
+    const right = { x: 267, y: 106 };
+
+    expect(straight.encompasses(above)).toBe(false);
+    expect(straight.encompasses(below)).toBe(false);
+    expect(straight.encompasses(left)).toBe(false);
+    expect(straight.encompasses(right)).toBe(false);
+  });
+
+  test("should encompass coords on border", () => {
+    const straight = new Straight(spec);
+    straight.setPosition({ x: 100, y: 100 });
+
+    const top = { x: 150, y: 100 };
+    const bottom = { x: 150, y: 122 };
+    const left = { x: 100, y: 106 };
+    const right = { x: 266, y: 106 };
+
+    expect(straight.encompasses(top)).toBe(true);
+    expect(straight.encompasses(bottom)).toBe(true);
+    expect(straight.encompasses(left)).toBe(true);
+    expect(straight.encompasses(right)).toBe(true);
+  });
+
+  test("should encompass coords inside", () => {
+    const straight = new Straight(spec);
+    straight.setPosition({ x: 100, y: 100 });
+
+    const centre = { x: 183, y: 111 };
+    expect(straight.encompasses(centre)).toBe(true);
+  });
 });

--- a/src/track/straight.ts
+++ b/src/track/straight.ts
@@ -1,5 +1,5 @@
-import { Coords } from "../lib/coords";
 import { SLEEPER_LENGTH } from "../constants";
+import { Coords } from "../lib/coords";
 
 type StraightSpec = {
   id: string;
@@ -17,11 +17,27 @@ class Straight {
   x = 0;
   y = 0;
 
+  mouseOffset?: Coords;
+
   constructor(spec: StraightSpec) {
     this.trackId = spec.id;
     this.catno = spec.catno;
     this.label = spec.label;
     this.length = spec.length;
+  }
+
+  dragGrabbed(coords: Coords) {
+    if (this.mouseOffset !== undefined) {
+      this.setPosition({
+        x: coords.x + this.mouseOffset.x,
+        y: coords.y + this.mouseOffset.y,
+      });
+    }
+  }
+
+  setPosition(coords: Coords) {
+    this.x = coords.x;
+    this.y = coords.y;
   }
 
   getDropOffset() {
@@ -31,9 +47,18 @@ class Straight {
     } as Coords;
   }
 
-  setPosition(coords: Coords) {
-    this.x = coords.x;
-    this.y = coords.y;
+  isGrabbed() {
+    return this.mouseOffset !== undefined;
+  }
+
+  onMouseDown(coords: Coords) {
+    if (this.encompasses(coords)) {
+      this.mouseOffset = { x: this.x - coords.x, y: this.y - coords.y };
+    }
+  }
+
+  onMouseUp() {
+    this.mouseOffset = undefined;
   }
 
   encompasses(coords: Coords) {

--- a/src/track/straight.ts
+++ b/src/track/straight.ts
@@ -13,6 +13,7 @@ class Straight {
   catno: string;
   label: string;
   length: number;
+  width = SLEEPER_LENGTH;
   x = 0;
   y = 0;
 
@@ -26,7 +27,7 @@ class Straight {
   getDropOffset() {
     return {
       x: this.length / 2,
-      y: SLEEPER_LENGTH / 2,
+      y: this.width / 2,
     } as Coords;
   }
 
@@ -35,10 +36,24 @@ class Straight {
     this.y = coords.y;
   }
 
+  encompasses(coords: Coords) {
+    const { x, y } = coords;
+
+    if (
+      x < this.x ||
+      y < this.y ||
+      x > this.x + this.length ||
+      y > this.y + this.width
+    ) {
+      return false;
+    }
+    return true;
+  }
+
   render(ctx: CanvasRenderingContext2D) {
     ctx.beginPath();
     ctx.fillStyle = "#0000ff";
-    ctx.rect(this.x, this.y, this.length, SLEEPER_LENGTH);
+    ctx.rect(this.x, this.y, this.length, this.width);
     ctx.fill();
 
     ctx.fillStyle = "#ffffff";
@@ -48,7 +63,7 @@ class Straight {
     ctx.fillText(
       this.catno,
       this.x + this.length / 2,
-      this.y + SLEEPER_LENGTH / 2,
+      this.y + this.width / 2,
       this.length,
     );
   }


### PR DESCRIPTION
## What?
I've added the ability to drag and drop track already on the board, closes #5.

## Why?
It's one of the core features we promised.

## How?
By giving Straight track pseudo onMouseDown() and onMouseUp() event handlers.  In board.ts I've implemented simple *onmouseup* and *onmousedown* event handlers to *bubble* their event to every track on the board.
Each track instance uses their new encompasses() method to determine if the event applies to them.
To give the appearance of movement, the board.draw() function recursively passes itself as an arg to requestAnimationFrame.

## Testing?
straight.test.ts - has been updated with tests for supporting functionality.
move_track.test.ts - contains the tests for dragging and dropping track.
board.ts - isn't tested directly but relies on the Straight classes' new functions tested above.

## Screenshots
The shot below is the result of rearranging the shapes - you don't really demonstrate a lot.
![image](https://github.com/user-attachments/assets/4ab1d83e-a615-41e0-9690-4d83b227e81c)

## Anything else?
Having the logic located in the Straight to determine if it should be dragged may be a bit clumsy for future features.