### PR TITLE
Add colour lookup table for each type of track

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,4 @@
+import { Swatch } from "./track/colour_chart";
 import { StraightSpec } from "./track/straight";
 
 const SLEEPER_LENGTH = 22;
@@ -17,4 +18,16 @@ const TRACK_CATALOG: StraightSpec[] = [
   },
 ];
 
-export { SLEEPER_LENGTH, TRACK_CATALOG };
+const COLOUR_CHART: Array<[string, string[]]> = [
+  ["1", ["#00ffff", "#20dfdf", "#107070", "#ffffff"]],
+  ["2", ["#d400ff", "#bf20df", "#601070", "#ffffff"]],
+];
+
+const DEFAULT_SWATCH: Swatch = {
+  highlight: "#0000ff", // hsl(240, 100, 50)
+  normal: "#2020df", // hsl(240,75,50)
+  shaded: "#101070", // hsl(240, 75, 24)
+  text: "#ffffff",
+};
+
+export { COLOUR_CHART, DEFAULT_SWATCH, SLEEPER_LENGTH, TRACK_CATALOG };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,8 +24,8 @@ const COLOUR_CHART: Array<[string, string[]]> = [
 ];
 
 const DEFAULT_SWATCH: Swatch = {
-  highlight: "#0000ff", // hsl(240, 100, 50)
-  normal: "#2020df", // hsl(240,75,50)
+  highlight: "#2040df", // hsl(240,75,50)
+  normal: "#002aff", // hsl(240, 100, 50)
   shaded: "#101070", // hsl(240, 75, 24)
   text: "#ffffff",
 };

--- a/src/track/colour_chart.test.ts
+++ b/src/track/colour_chart.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from "vitest";
 import { colourChart, Swatch } from "./colour_chart";
+import { DEFAULT_SWATCH } from "../constants";
 
 describe("colour chart", () => {
   test("should lookup colour for track", () => {
@@ -30,7 +31,7 @@ describe("colour chart", () => {
     const colourLookup = colourChart([]);
     const swatch = colourLookup("82");
 
-    expect(swatch.highlight).toBe("#0000ff");
+    expect(swatch.shaded).toBe(DEFAULT_SWATCH.shaded);
   });
 });
 
@@ -49,12 +50,14 @@ describe("supplied colour chart", () => {
   test("should return default", () => {
     const swatch = colourLookup("99");
 
-    expect(swatch.highlight).toBe("#0000ff");
+    expect(swatch.highlight).toBe(DEFAULT_SWATCH.highlight);
   });
 
-  test("should return mangenta", () => {
+  test("should return chart's defined colour", () => {
     const swatch = colourLookup("2");
 
-    expect(swatch.normal).toBe("#bf20df");
+    const [, [, normal]] = chart[1];
+
+    expect(swatch.normal).toBe(normal);
   });
 });

--- a/src/track/colour_chart.test.ts
+++ b/src/track/colour_chart.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { colourChart, Swatch } from "./colour_chart";
+
+describe("colour chart", () => {
+  test("should lookup colour for track", () => {
+    const colourLookup = colourChart([]);
+
+    expect(colourLookup).not.toBeUndefined();
+  });
+
+  test("should return colour options for a track", () => {
+    const colourLookup = colourChart([]);
+
+    const swatch = colourLookup("1");
+
+    expect(swatch).not.toBeUndefined();
+  });
+
+  test("should return object with colour swatch", () => {
+    const colourLookup = colourChart([]);
+
+    const swatch = colourLookup("1");
+
+    expect(swatch).toHaveProperty("normal");
+    expect(swatch).toHaveProperty("shaded");
+    expect(swatch).toHaveProperty("text");
+  });
+
+  test("should return default colour swatch", () => {
+    const colourLookup = colourChart([]);
+    const swatch = colourLookup("82");
+
+    expect(swatch.highlight).toBe("#0000ff");
+  });
+});
+
+describe("supplied colour chart", () => {
+  let colourLookup: (k: string) => Swatch;
+
+  const chart: Array<[string, string[]]> = [
+    ["1", ["#00ffff", "#20dfdf", "#107070", "#ffffff"]],
+    ["2", ["#d400ff", "#bf20df", "#601070", "#ffffff"]],
+  ];
+
+  beforeEach(() => {
+    colourLookup = colourChart(chart);
+  });
+
+  test("should return default", () => {
+    const swatch = colourLookup("99");
+
+    expect(swatch.highlight).toBe("#0000ff");
+  });
+
+  test("should return mangenta", () => {
+    const swatch = colourLookup("2");
+
+    expect(swatch.normal).toBe("#bf20df");
+  });
+});

--- a/src/track/colour_chart.test.ts
+++ b/src/track/colour_chart.test.ts
@@ -1,26 +1,26 @@
 import { beforeEach, describe, expect, test } from "vitest";
-import { colourChart, Swatch } from "./colour_chart";
+import { colourLookup, Swatch } from "./colour_chart";
 import { DEFAULT_SWATCH } from "../constants";
 
 describe("colour chart", () => {
   test("should lookup colour for track", () => {
-    const colourLookup = colourChart([]);
+    const colourChart = colourLookup([]);
 
-    expect(colourLookup).not.toBeUndefined();
+    expect(colourChart).not.toBeUndefined();
   });
 
   test("should return colour options for a track", () => {
-    const colourLookup = colourChart([]);
+    const colourChart = colourLookup([]);
 
-    const swatch = colourLookup("1");
+    const swatch = colourChart("1");
 
     expect(swatch).not.toBeUndefined();
   });
 
   test("should return object with colour swatch", () => {
-    const colourLookup = colourChart([]);
+    const colourChart = colourLookup([]);
 
-    const swatch = colourLookup("1");
+    const swatch = colourChart("1");
 
     expect(swatch).toHaveProperty("normal");
     expect(swatch).toHaveProperty("shaded");
@@ -28,15 +28,15 @@ describe("colour chart", () => {
   });
 
   test("should return default colour swatch", () => {
-    const colourLookup = colourChart([]);
-    const swatch = colourLookup("82");
+    const colourChart = colourLookup([]);
+    const swatch = colourChart("82");
 
     expect(swatch.shaded).toBe(DEFAULT_SWATCH.shaded);
   });
 });
 
 describe("supplied colour chart", () => {
-  let colourLookup: (k: string) => Swatch;
+  let colourChart: (k: string) => Swatch;
 
   const chart: Array<[string, string[]]> = [
     ["1", ["#00ffff", "#20dfdf", "#107070", "#ffffff"]],
@@ -44,17 +44,17 @@ describe("supplied colour chart", () => {
   ];
 
   beforeEach(() => {
-    colourLookup = colourChart(chart);
+    colourChart = colourLookup(chart);
   });
 
   test("should return default", () => {
-    const swatch = colourLookup("99");
+    const swatch = colourChart("99");
 
     expect(swatch.highlight).toBe(DEFAULT_SWATCH.highlight);
   });
 
   test("should return chart's defined colour", () => {
-    const swatch = colourLookup("2");
+    const swatch = colourChart("2");
 
     const [, [, normal]] = chart[1];
 

--- a/src/track/colour_chart.test.ts
+++ b/src/track/colour_chart.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from "vitest";
-import { colourLookup, Swatch } from "./colour_chart";
 import { DEFAULT_SWATCH } from "../constants";
+import { colourLookup, Swatch } from "./colour_chart";
 
 describe("colour chart", () => {
   test("should lookup colour for track", () => {

--- a/src/track/colour_chart.ts
+++ b/src/track/colour_chart.ts
@@ -20,4 +20,4 @@ function colourLookup(chart: Array<[string, string[]]>): ColourChart {
     swatches.has(id) ? (swatches.get(id) as Swatch) : DEFAULT_SWATCH;
 }
 
-export { colourLookup, type Swatch, type ColourChart };
+export { colourLookup, type ColourChart, type Swatch };

--- a/src/track/colour_chart.ts
+++ b/src/track/colour_chart.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_SWATCH } from "../constants";
+
 type Swatch = {
   highlight: string;
   normal: string;
@@ -5,14 +7,9 @@ type Swatch = {
   text: string;
 };
 
-const other: Swatch = {
-  highlight: "#0000ff", // hsl(240, 100, 50)
-  normal: "#2020df", // hsl(240,75,50)
-  shaded: "#101070", // hsl(240, 75, 24)
-  text: "#ffffff",
-};
+type ColourChart = (key: string) => Swatch;
 
-function colourChart(chart: Array<[string, string[]]>) {
+function colourLookup(chart: Array<[string, string[]]>): ColourChart {
   const swatches = chart.reduce((acc, [id, swatch]) => {
     const [highlight, normal, shaded, text] = swatch;
 
@@ -20,7 +17,7 @@ function colourChart(chart: Array<[string, string[]]>) {
   }, new Map<string, Swatch>());
 
   return (id: string): Swatch =>
-    swatches.has(id) ? (swatches.get(id) as Swatch) : other;
+    swatches.has(id) ? (swatches.get(id) as Swatch) : DEFAULT_SWATCH;
 }
 
-export { colourChart, type Swatch };
+export { colourLookup as colourChart, type Swatch, type ColourChart };

--- a/src/track/colour_chart.ts
+++ b/src/track/colour_chart.ts
@@ -20,4 +20,4 @@ function colourLookup(chart: Array<[string, string[]]>): ColourChart {
     swatches.has(id) ? (swatches.get(id) as Swatch) : DEFAULT_SWATCH;
 }
 
-export { colourLookup as colourChart, type Swatch, type ColourChart };
+export { colourLookup, type Swatch, type ColourChart };

--- a/src/track/colour_chart.ts
+++ b/src/track/colour_chart.ts
@@ -1,0 +1,26 @@
+type Swatch = {
+  highlight: string;
+  normal: string;
+  shaded: string;
+  text: string;
+};
+
+const other: Swatch = {
+  highlight: "#0000ff", // hsl(240, 100, 50)
+  normal: "#2020df", // hsl(240,75,50)
+  shaded: "#101070", // hsl(240, 75, 24)
+  text: "#ffffff",
+};
+
+function colourChart(chart: Array<[string, string[]]>) {
+  const swatches = chart.reduce((acc, [id, swatch]) => {
+    const [highlight, normal, shaded, text] = swatch;
+
+    return acc.set(id, { highlight, normal, shaded, text } as Swatch);
+  }, new Map<string, Swatch>());
+
+  return (id: string): Swatch =>
+    swatches.has(id) ? (swatches.get(id) as Swatch) : other;
+}
+
+export { colourChart, type Swatch };

--- a/src/track/straight.test.ts
+++ b/src/track/straight.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { SLEEPER_LENGTH } from "../constants";
-import { Straight, StraightSpec } from "./straight";
 import { Swatch } from "./colour_chart";
+import { Straight, StraightSpec } from "./straight";
 
 const spec: StraightSpec = {
   id: "1",

--- a/src/track/straight.test.ts
+++ b/src/track/straight.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { SLEEPER_LENGTH } from "../constants";
 import { Straight, StraightSpec } from "./straight";
+import { Swatch } from "./colour_chart";
 
 const spec: StraightSpec = {
   id: "1",
@@ -79,5 +80,31 @@ describe("Straight", () => {
 
     const centre = { x: 183, y: 111 };
     expect(straight.encompasses(centre)).toBe(true);
+  });
+
+  test("should have a swatch property", () => {
+    const straight = new Straight(spec);
+
+    expect(straight).toHaveProperty("swatch");
+  });
+
+  test("should have default swatch", () => {
+    const straight = new Straight(spec);
+
+    expect(straight.swatch.text).toBe("#ffffff");
+  });
+
+  test("should replace default swatch", () => {
+    const red: Swatch = {
+      highlight: "#00ff00",
+      normal: "#00ff01",
+      shaded: "#00ff02",
+      text: "#ffffff",
+    };
+
+    const straight = new Straight(spec);
+    straight.setSwatch(red);
+
+    expect(straight.swatch.shaded).toBe("#00ff02");
   });
 });

--- a/src/track/straight.ts
+++ b/src/track/straight.ts
@@ -16,6 +16,9 @@ class Straight {
   length: number;
   width = SLEEPER_LENGTH;
   swatch: Swatch = DEFAULT_SWATCH;
+  fillColour: keyof Swatch;
+  textColour: keyof Swatch;
+
   x = 0;
   y = 0;
 
@@ -26,6 +29,8 @@ class Straight {
     this.catno = spec.catno;
     this.label = spec.label;
     this.length = spec.length;
+    this.fillColour = "normal";
+    this.textColour = "text";
   }
 
   dragGrabbed(coords: Coords) {
@@ -60,11 +65,13 @@ class Straight {
   onMouseDown(coords: Coords) {
     if (this.encompasses(coords)) {
       this.mouseOffset = { x: this.x - coords.x, y: this.y - coords.y };
+      this.fillColour = "highlight";
     }
   }
 
   onMouseUp() {
     this.mouseOffset = undefined;
+    this.fillColour = "normal";
   }
 
   encompasses(coords: Coords) {
@@ -83,11 +90,11 @@ class Straight {
 
   render(ctx: CanvasRenderingContext2D) {
     ctx.beginPath();
-    ctx.fillStyle = "#0000ff";
+    ctx.fillStyle = this.swatch[this.fillColour];
     ctx.rect(this.x, this.y, this.length, this.width);
     ctx.fill();
 
-    ctx.fillStyle = "#ffffff";
+    ctx.fillStyle = this.swatch[this.textColour];
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
     ctx.font = "18px arial";

--- a/src/track/straight.ts
+++ b/src/track/straight.ts
@@ -1,5 +1,6 @@
-import { SLEEPER_LENGTH } from "../constants";
+import { DEFAULT_SWATCH, SLEEPER_LENGTH } from "../constants";
 import { Coords } from "../lib/coords";
+import { Swatch } from "./colour_chart";
 
 type StraightSpec = {
   id: string;
@@ -14,6 +15,7 @@ class Straight {
   label: string;
   length: number;
   width = SLEEPER_LENGTH;
+  swatch: Swatch = DEFAULT_SWATCH;
   x = 0;
   y = 0;
 
@@ -38,6 +40,10 @@ class Straight {
   setPosition(coords: Coords) {
     this.x = coords.x;
     this.y = coords.y;
+  }
+
+  setSwatch(swatch: Swatch) {
+    this.swatch = swatch;
   }
 
   getDropOffset() {

--- a/src/track/track_manager.test.ts
+++ b/src/track/track_manager.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, test } from "vitest";
 import { StraightSpec } from "./straight";
 import { TrackManager } from "./track_manager";
 import { Coords } from "../lib/coords";
-import { SLEEPER_LENGTH } from "../constants";
+import { COLOUR_CHART, DEFAULT_SWATCH, SLEEPER_LENGTH } from "../constants";
 
 const catalog: StraightSpec[] = [
   {
@@ -78,5 +78,15 @@ describe("add new track", () => {
 
     expect(track.x).toBe(expectedX);
     expect(track.y).toBe(expectedY);
+  });
+});
+
+describe("colour chart", () => {
+  test("should use COLOUR_CHART", () => {
+    manager.add("1", position);
+
+    const [, [highlight]] = COLOUR_CHART[0];
+
+    expect(manager.tracks[0].swatch.highlight).toBe(highlight);
   });
 });

--- a/src/track/track_manager.test.ts
+++ b/src/track/track_manager.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, test } from "vitest";
+import { COLOUR_CHART, SLEEPER_LENGTH } from "../constants";
+import { Coords } from "../lib/coords";
 import { StraightSpec } from "./straight";
 import { TrackManager } from "./track_manager";
-import { Coords } from "../lib/coords";
-import { COLOUR_CHART, DEFAULT_SWATCH, SLEEPER_LENGTH } from "../constants";
 
 const catalog: StraightSpec[] = [
   {

--- a/src/track/track_manager.ts
+++ b/src/track/track_manager.ts
@@ -1,12 +1,17 @@
+import { COLOUR_CHART } from "../constants";
 import { Coords } from "../lib/coords";
+import { colourLookup, ColourChart } from "./colour_chart";
 import { Straight, StraightSpec } from "./straight";
 
 class TrackManager {
   readonly catalog: StraightSpec[] = [];
   readonly tracks: Straight[] = [];
+  readonly colourChart: ColourChart;
 
   constructor(catalog: StraightSpec[]) {
     this.catalog = catalog;
+
+    this.colourChart = colourLookup(COLOUR_CHART);
   }
 
   add(productId: string, coords: Coords) {
@@ -20,6 +25,7 @@ class TrackManager {
     const offset = track.getDropOffset();
     const position = { x: coords.x - offset.x, y: coords.y - offset.y };
     track.setPosition(position);
+    track.setSwatch(this.colourChart(spec.id));
 
     this.tracks.push(track);
   }

--- a/src/track/track_manager.ts
+++ b/src/track/track_manager.ts
@@ -1,6 +1,6 @@
 import { COLOUR_CHART } from "../constants";
 import { Coords } from "../lib/coords";
-import { colourLookup, ColourChart } from "./colour_chart";
+import { ColourChart, colourLookup } from "./colour_chart";
 import { Straight, StraightSpec } from "./straight";
 
 class TrackManager {


### PR DESCRIPTION
## What?
I've introduced a mechanism for creating a colour lookup table that defines the colour of track dragged from the track palette covering.
It sets four colours: highlight, normal, shaded and text.

## Why? 
Even laying either of the two straights currently defined was confusing with no differentiation between them.

## Testing?
Additional tests have been added to the existing test files.

## Screenshots (optional)
A shot illustrating the different coloured track
![image](https://github.com/user-attachments/assets/19c76a13-911d-4fcb-8219-fc5afb091a06)

## Anything else?
Colour 'Swatch' objects are set on the Straight class using a setSwatch() method rather than adding it to the constructor params while TrackManager builds the lookup within its constructor.  This should close #22.