### PR TITLE
Z index

### DIFF
--- a/src/components/board.ts
+++ b/src/components/board.ts
@@ -1,3 +1,4 @@
+import { Coords } from "../lib/coords";
 import { StraightSpec } from "../track/straight";
 import { TrackManager } from "../track/track_manager";
 
@@ -8,6 +9,9 @@ let viewWidth: number;
 let viewHeight: number;
 
 let trackManager: TrackManager;
+
+let zIndex = 0;
+let selected: { id: string; coords: Coords } | undefined;
 
 function setup(trackCatalog: StraightSpec[]) {
   setupCanvas();
@@ -20,10 +24,20 @@ function setup(trackCatalog: StraightSpec[]) {
 }
 
 function draw() {
+  const zIndexOrder = trackManager.tracks
+    .slice()
+    .sort((a, b) => a.zIndex - b.zIndex);
+
   ctx.clearRect(0, 0, viewWidth, viewHeight);
 
-  for (const track of trackManager.tracks) {
+  for (const track of zIndexOrder) {
     track.render(ctx);
+  }
+
+  if (selected !== undefined) {
+    const track = trackManager.tracks.find((t) => t.id === selected?.id);
+
+    track?.render(ctx);
   }
 
   requestAnimationFrame(draw);
@@ -62,7 +76,8 @@ function setupDragHandlers() {
     if (dropped) {
       const [_, id] = dropped.split("#");
 
-      trackManager.add(id, { x: ev.offsetX, y: ev.offsetY });
+      const track = trackManager.add(id, { x: ev.offsetX, y: ev.offsetY });
+      track?.setZIndex(zIndex++);
 
       draw();
     }
@@ -75,13 +90,29 @@ function setupMouseHandlers() {
   canvas.onmousedown = (ev: MouseEvent) => {
     const mouseXY = { x: ev.offsetX, y: ev.offsetY };
 
-    for (const track of trackManager.tracks) {
-      track.onMouseDown(mouseXY);
+    const clicked = trackManager.getTrackAt(mouseXY);
+
+    if (clicked.length === 0) {
+      return;
     }
+
+    const track = clicked.reduce((top, t) => (t.zIndex > top.zIndex ? t : top));
+
+    selected = { id: track.id, coords: { x: track.x, y: track.y } };
+
+    track.onMouseDown(mouseXY);
   };
 
   canvas.onmouseup = () => {
-    for (const track of trackManager.tracks) {
+    const track = trackManager.tracks.find((t) => t.id === selected?.id);
+
+    if (track !== undefined) {
+      if (selected !== undefined) {
+        if (selected.coords.x !== track.x || selected.coords.y !== track.y) {
+          track.setZIndex(zIndex++);
+        }
+        selected = undefined;
+      }
       track.onMouseUp();
     }
   };

--- a/src/components/board.ts
+++ b/src/components/board.ts
@@ -1,4 +1,4 @@
-import { TRACK_CATALOG } from "../constants";
+import { StraightSpec } from "../track/straight";
 import { TrackManager } from "../track/track_manager";
 
 let canvas: HTMLCanvasElement;
@@ -9,12 +9,12 @@ let viewHeight: number;
 
 let trackManager: TrackManager;
 
-function setup() {
+function setup(trackCatalog: StraightSpec[]) {
   setupCanvas();
   setupDragHandlers();
   setupMouseHandlers();
 
-  trackManager = new TrackManager(TRACK_CATALOG);
+  trackManager = new TrackManager(trackCatalog);
 
   requestAnimationFrame(draw);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,10 @@
 import * as board from "./components/board";
 import * as palette from "./components/palette";
+import { TRACK_CATALOG } from "./constants";
 
 window.onload = setup;
 
 function setup() {
-  board.setup();
+  board.setup(TRACK_CATALOG);
   palette.setup();
 }

--- a/src/track/straight.test.ts
+++ b/src/track/straight.test.ts
@@ -11,6 +11,13 @@ const spec: StraightSpec = {
 };
 
 describe("Straight", () => {
+  test("should be assigned an id", () => {
+    const straight = new Straight(spec);
+
+    expect(straight).toHaveProperty("id");
+    expect(straight.id).toHaveLength(21);
+  });
+
   test("should have catno and length", () => {
     const straight = new Straight(spec);
 

--- a/src/track/straight.ts
+++ b/src/track/straight.ts
@@ -18,6 +18,7 @@ class Straight {
   swatch: Swatch = DEFAULT_SWATCH;
   fillColour: keyof Swatch;
   textColour: keyof Swatch;
+  indexZ = 0;
 
   x = 0;
   y = 0;
@@ -49,6 +50,10 @@ class Straight {
 
   setSwatch(swatch: Swatch) {
     this.swatch = swatch;
+  }
+
+  setIndexZ(indexZ: number) {
+    this.indexZ = indexZ;
   }
 
   getDropOffset() {
@@ -89,8 +94,10 @@ class Straight {
   }
 
   render(ctx: CanvasRenderingContext2D) {
-    ctx.beginPath();
+    ctx.save();
+
     ctx.fillStyle = this.swatch[this.fillColour];
+    ctx.beginPath();
     ctx.rect(this.x, this.y, this.length, this.width);
     ctx.fill();
 
@@ -98,12 +105,15 @@ class Straight {
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
     ctx.font = "18px arial";
+    ctx.beginPath();
     ctx.fillText(
       this.catno,
       this.x + this.length / 2,
       this.y + this.width / 2,
       this.length,
     );
+
+    ctx.restore();
   }
 }
 

--- a/src/track/straight.ts
+++ b/src/track/straight.ts
@@ -18,7 +18,7 @@ class Straight {
   swatch: Swatch = DEFAULT_SWATCH;
   fillColour: keyof Swatch;
   textColour: keyof Swatch;
-  indexZ = 0;
+  zIndex = 0;
 
   x = 0;
   y = 0;
@@ -52,8 +52,8 @@ class Straight {
     this.swatch = swatch;
   }
 
-  setIndexZ(indexZ: number) {
-    this.indexZ = indexZ;
+  setZIndex(zIndex: number) {
+    this.zIndex = zIndex;
   }
 
   getDropOffset() {

--- a/src/track/straight.ts
+++ b/src/track/straight.ts
@@ -1,3 +1,4 @@
+import { nanoid } from "nanoid";
 import { DEFAULT_SWATCH, SLEEPER_LENGTH } from "../constants";
 import { Coords } from "../lib/coords";
 import { Swatch } from "./colour_chart";
@@ -10,6 +11,7 @@ type StraightSpec = {
 };
 
 class Straight {
+  id: string;
   trackId: string;
   catno: string;
   label: string;
@@ -26,6 +28,7 @@ class Straight {
   mouseOffset?: Coords;
 
   constructor(spec: StraightSpec) {
+    this.id = nanoid();
     this.trackId = spec.id;
     this.catno = spec.catno;
     this.label = spec.label;

--- a/src/track/track_manager.test.ts
+++ b/src/track/track_manager.test.ts
@@ -63,6 +63,12 @@ describe("add new track", () => {
     expect(track).toBeUndefined();
   });
 
+  test("should return known track", () => {
+    const track = manager.add("2", position);
+
+    expect(track?.catno).toBe("TT8039");
+  });
+
   test("should hold a single double length straight", () => {
     manager.add("2", position);
 

--- a/src/track/track_manager.ts
+++ b/src/track/track_manager.ts
@@ -28,6 +28,8 @@ class TrackManager {
     track.setSwatch(this.colourChart(spec.id));
 
     this.tracks.push(track);
+
+    return track;
   }
 
   getTrackAt(coords: Coords) {

--- a/src/track/track_manager.ts
+++ b/src/track/track_manager.ts
@@ -30,7 +30,7 @@ class TrackManager {
     this.tracks.push(track);
   }
 
-  getTracksAt(coords: Coords) {
+  getTrackAt(coords: Coords) {
     return this.tracks.filter((t) => t.encompasses(coords));
   }
 }

--- a/src/track/track_manager.ts
+++ b/src/track/track_manager.ts
@@ -29,6 +29,10 @@ class TrackManager {
 
     this.tracks.push(track);
   }
+
+  getTracksAt(coords: Coords) {
+    return this.tracks.filter((t) => t.encompasses(coords));
+  }
 }
 
 export { TrackManager };

--- a/src/track/z_index.test.ts
+++ b/src/track/z_index.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { TrackManager } from "./track_manager";
+
+let manager: TrackManager;
+
+const spec = { id: "0", catno: "TEST0200", label: "200mm", length: 200 };
+
+beforeEach(() => {
+  manager = new TrackManager([spec]);
+  manager.add("0", { x: 100, y: 100 });
+  manager.add("0", { x: 200, y: 110 });
+
+  console.log(`first:(${manager.tracks[0].x}, ${manager.tracks[0].y})`);
+  console.log(`second:(${manager.tracks[1].x}, ${manager.tracks[1].y})`);
+});
+
+describe("z-index", () => {
+  test("should not be any track", () => {
+    expect(manager.getTracksAt({ x: 40, y: 50 })).toHaveLength(0);
+  });
+
+  test("should find single track", () => {
+    expect(manager.getTracksAt({ x: 50, y: 100 })).toHaveLength(1);
+  });
+
+  test("should find two tracks", () => {
+    expect(manager.getTracksAt({ x: 150, y: 108 })).toHaveLength(2);
+  });
+});

--- a/src/track/z_index.test.ts
+++ b/src/track/z_index.test.ts
@@ -30,7 +30,7 @@ describe("TrackManager z-index", () => {
 });
 
 describe("Straight z-index", () => {
-  test("should have defaualt z-index of zero", () => {
+  test("should have default z-index of zero", () => {
     const straight = new Straight(spec);
 
     expect(straight.zIndex).toBe(0);

--- a/src/track/z_index.test.ts
+++ b/src/track/z_index.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from "vitest";
-import { TrackManager } from "./track_manager";
 import { Straight } from "./straight";
+import { TrackManager } from "./track_manager";
 
 let manager: TrackManager;
 

--- a/src/track/z_index.test.ts
+++ b/src/track/z_index.test.ts
@@ -17,15 +17,15 @@ beforeEach(() => {
 
 describe("TrackManager z-index", () => {
   test("should not be any track", () => {
-    expect(manager.getTracksAt({ x: 40, y: 50 })).toHaveLength(0);
+    expect(manager.getTrackAt({ x: 40, y: 50 })).toHaveLength(0);
   });
 
   test("should find single track", () => {
-    expect(manager.getTracksAt({ x: 50, y: 100 })).toHaveLength(1);
+    expect(manager.getTrackAt({ x: 50, y: 100 })).toHaveLength(1);
   });
 
   test("should find two tracks", () => {
-    expect(manager.getTracksAt({ x: 150, y: 108 })).toHaveLength(2);
+    expect(manager.getTrackAt({ x: 150, y: 108 })).toHaveLength(2);
   });
 });
 
@@ -33,13 +33,13 @@ describe("Straight z-index", () => {
   test("should have defaualt z-index of zero", () => {
     const straight = new Straight(spec);
 
-    expect(straight.indexZ).toBe(0);
+    expect(straight.zIndex).toBe(0);
   });
 
   test("should have z-index set to ten", () => {
     const straight = new Straight(spec);
-    straight.setIndexZ(10);
+    straight.setZIndex(10);
 
-    expect(straight.indexZ).toBe(10);
+    expect(straight.zIndex).toBe(10);
   });
 });

--- a/src/track/z_index.test.ts
+++ b/src/track/z_index.test.ts
@@ -10,9 +10,6 @@ beforeEach(() => {
   manager = new TrackManager([spec]);
   manager.add("0", { x: 100, y: 100 });
   manager.add("0", { x: 200, y: 110 });
-
-  console.log(`first:(${manager.tracks[0].x}, ${manager.tracks[0].y})`);
-  console.log(`second:(${manager.tracks[1].x}, ${manager.tracks[1].y})`);
 });
 
 describe("TrackManager z-index", () => {

--- a/src/track/z_index.test.ts
+++ b/src/track/z_index.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from "vitest";
 import { TrackManager } from "./track_manager";
+import { Straight } from "./straight";
 
 let manager: TrackManager;
 
@@ -14,7 +15,7 @@ beforeEach(() => {
   console.log(`second:(${manager.tracks[1].x}, ${manager.tracks[1].y})`);
 });
 
-describe("z-index", () => {
+describe("TrackManager z-index", () => {
   test("should not be any track", () => {
     expect(manager.getTracksAt({ x: 40, y: 50 })).toHaveLength(0);
   });
@@ -25,5 +26,20 @@ describe("z-index", () => {
 
   test("should find two tracks", () => {
     expect(manager.getTracksAt({ x: 150, y: 108 })).toHaveLength(2);
+  });
+});
+
+describe("Straight z-index", () => {
+  test("should have defaualt z-index of zero", () => {
+    const straight = new Straight(spec);
+
+    expect(straight.indexZ).toBe(0);
+  });
+
+  test("should have z-index set to ten", () => {
+    const straight = new Straight(spec);
+    straight.setIndexZ(10);
+
+    expect(straight.indexZ).toBe(10);
   });
 });


### PR DESCRIPTION
## What?
When a piece of track is clicked, only the top-most track is selected.
When a piece of track is dragged around the board it will be left on top of any track it was dragged over.
This closes #23.

## Why?
Previously, rendering was done in the order track had been dropped onto the canvas and if several pieces of track were found at the point the mouse was clicked they'd all follow the mouse.

## How?
I've introduced the notion of z-index to items of track on the board.  Each time a new piece is added the board allocates it the next z-index.  Likewise, when a piece of track is dragged, if it was moved board assigns the incremented z-index.

I've also had to sort the track array in z-index order so they're rendered with the highest z-index on top.

## Screenshots (optional)
Before dragging bottom track...
![image](https://github.com/user-attachments/assets/4a032637-dae6-4210-91d7-e795d8744467)

After dragging bottom track...
![image](https://github.com/user-attachments/assets/06fb0b1f-e377-4580-90f4-2ae8f3a4d119)

## Anything else?
n/a