### PR TITLE
Replace Palette HTML with a dynamic component

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,25 +10,7 @@
   </head>
   <body>
     <div id="app">
-      <aside class="sidebar">
-        <div class="palette">
-          <p class="title">Straights</p>
-          <ul class="items">
-            <li>
-              <div data-track-id="1" class="item track" draggable="true">
-                <span class="label">166mm</span>
-                <span class="catno">TT8002</span>
-              </div>
-            </li>
-            <li>
-              <div data-track-id="2" class="item track" draggable="true">
-                <span class="label">332mm</span>
-                <span class="catno">TT8039</span>
-              </div>
-            </li>
-          </ul>
-        </div>
-      </aside>
+      <aside class="sidebar"></aside>
 
       <main class="main">
         <div class="container">

--- a/src/components/palette.ts
+++ b/src/components/palette.ts
@@ -1,23 +1,44 @@
-function setup() {
-  const items = document.querySelectorAll<HTMLDivElement>(
-    "div.item.track[draggable='true']",
-  );
+import { StraightSpec } from "../track/straight";
+
+function create(title: string, items: StraightSpec[]) {
+  const paletteDiv = document.createElement("div");
+  paletteDiv.classList.add("palette");
+
+  const titleP = document.createElement("p");
+  paletteDiv.appendChild(titleP);
+  titleP.innerText = title;
+  titleP.classList.add("title");
+
+  const itemsUList = document.createElement("ul");
+  paletteDiv.appendChild(itemsUList);
+  itemsUList.classList.add("items");
 
   for (const item of items) {
-    item.ondragstart = handleDragStart;
+    const itemLI = document.createElement("li");
+    itemsUList.appendChild(itemLI);
+
+    const itemDiv = document.createElement("div");
+    itemLI.appendChild(itemDiv);
+    itemDiv.classList.add("item", "track", "straight");
+    itemDiv.draggable = true;
+    itemDiv.dataset.trackId = item.id;
+
+    itemDiv.ondragstart = (ev: DragEvent) => {
+      ev.dataTransfer?.setData("text/plain", `track#${item.id}`);
+    };
+
+    const labelSpan = document.createElement("span");
+    itemDiv.appendChild(labelSpan);
+    labelSpan.classList.add("label");
+    labelSpan.innerText = item.label;
+
+    const catnoSpan = document.createElement("span");
+    itemDiv.appendChild(catnoSpan);
+    catnoSpan.classList.add("catno");
+    catnoSpan.innerText = item.catno;
   }
+
+  return paletteDiv;
 }
 
-// Drag Event handlers
-
-function handleDragStart(ev: DragEvent) {
-  const item = ev.currentTarget as HTMLDivElement;
-
-  const trackId = item.dataset.trackId;
-
-  if (trackId) {
-    ev.dataTransfer!.setData("text/plain", `track#${trackId}`);
-  }
-}
-
-export { setup };
+export { create };

--- a/src/components/sidebar.ts
+++ b/src/components/sidebar.ts
@@ -1,0 +1,13 @@
+import { StraightSpec } from "../track/straight";
+import * as palette from "./palette";
+
+function setup(trackCatalog: StraightSpec[]) {
+  const sidebar = document.querySelector<HTMLDivElement>(".sidebar");
+
+  if (sidebar !== null) {
+    const straights = palette.create("Straights", trackCatalog);
+    sidebar.appendChild(straights);
+  }
+}
+
+export { setup };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,10 @@
 import * as board from "./components/board";
-import * as palette from "./components/palette";
+import * as sidebar from "./components/sidebar";
 import { TRACK_CATALOG } from "./constants";
 
 window.onload = setup;
 
 function setup() {
   board.setup(TRACK_CATALOG);
-  palette.setup();
+  sidebar.setup(TRACK_CATALOG);
 }


### PR DESCRIPTION
## What?
I've created a (not web) component to display a track palette to replace the hard coded HTML palette.  This closes #29.

## Why?
As we add more variety of track types we would have had to add more and more HTML which would also include hard coded id's for drag n drop purposes.

## How?
This isn't a web component, just an old school createElement/appendChild component.  It takes a title and list of items and wraps the components around these.  It also wires up an "ondragstart" event handler to take care of that.

## Testing?
Screenshot only

## Screenshots (optional)
Shot of the original and the new dynamically generated palette
![image](https://github.com/user-attachments/assets/b55bc085-b2c7-4c33-8afc-f52168eae7a3)

## Anything else?
A WebComponent was considered but seemed a bit overkill for this.