### PR TITLE
Remove coords

### DIFF
--- a/src/lib/coords.ts
+++ b/src/lib/coords.ts
@@ -1,3 +1,0 @@
-type Coords = { x: number; y: number };
-
-export { type Coords };

--- a/src/lib/vector.test.ts
+++ b/src/lib/vector.test.ts
@@ -6,8 +6,8 @@ describe("Vector", () => {
     const vector = new Vector(3, 4);
 
     expect(vector).not.toBeUndefined();
-    expect(vector.X).toBe(3);
-    expect(vector.Y).toBe(4);
+    expect(vector.x).toBe(3);
+    expect(vector.y).toBe(4);
   });
 
   test("should add vectors", () => {
@@ -17,8 +17,8 @@ describe("Vector", () => {
 
     const sum = v1.add(v2);
 
-    expect(sum.X).toBe(16);
-    expect(sum.Y).toBe(9);
+    expect(sum.x).toBe(16);
+    expect(sum.y).toBe(9);
   });
 
   test("should subtract vectors", () => {
@@ -28,8 +28,8 @@ describe("Vector", () => {
 
     const diff = v1.subtract(v2);
 
-    expect(diff.X).toBe(-8);
-    expect(diff.Y).toBe(-3);
+    expect(diff.x).toBe(-8);
+    expect(diff.y).toBe(-3);
   });
 
   test("should not be equal", () => {
@@ -50,7 +50,7 @@ describe("Vector", () => {
     const vector = Vector.of(10, 20);
 
     expect(vector).not.toBeUndefined();
-    expect(vector.X).toBe(10);
-    expect(vector.Y).toBe(20);
+    expect(vector.x).toBe(10);
+    expect(vector.y).toBe(20);
   });
 });

--- a/src/lib/vector.ts
+++ b/src/lib/vector.ts
@@ -11,11 +11,11 @@ class Vector {
     this._y = y;
   }
 
-  get X() {
+  get x() {
     return this._x;
   }
 
-  get Y() {
+  get y() {
     return this._y;
   }
 

--- a/src/track/straight.test.ts
+++ b/src/track/straight.test.ts
@@ -29,8 +29,8 @@ describe("Straight", () => {
   test("should have default position", () => {
     const straight = new Straight(spec);
 
-    expect(straight.position.X).toBe(0);
-    expect(straight.position.Y).toBe(0);
+    expect(straight.position.x).toBe(0);
+    expect(straight.position.y).toBe(0);
   });
 
   test("should have given position", () => {
@@ -38,8 +38,8 @@ describe("Straight", () => {
 
     straight.setPosition(Vector.of(100, 200));
 
-    expect(straight.position.X).toBe(100);
-    expect(straight.position.Y).toBe(200);
+    expect(straight.position.x).toBe(100);
+    expect(straight.position.y).toBe(200);
   });
 
   test("should not encompass outside coords", () => {

--- a/src/track/straight.ts
+++ b/src/track/straight.ts
@@ -51,10 +51,10 @@ class Straight {
 
   encompasses(vector: Vector) {
     if (
-      vector.X < this.position.X ||
-      vector.Y < this.position.Y ||
-      vector.X > this.position.X + this.length ||
-      vector.Y > this.position.Y + this.width
+      vector.x < this.position.x ||
+      vector.y < this.position.y ||
+      vector.x > this.position.x + this.length ||
+      vector.y > this.position.y + this.width
     ) {
       return false;
     }
@@ -66,7 +66,7 @@ class Straight {
 
     ctx.fillStyle = this.swatch[this.fillColour];
     ctx.beginPath();
-    ctx.rect(this.position.X, this.position.Y, this.length, this.width);
+    ctx.rect(this.position.x, this.position.y, this.length, this.width);
     ctx.fill();
 
     ctx.fillStyle = this.swatch[this.textColour];
@@ -76,8 +76,8 @@ class Straight {
     ctx.beginPath();
     ctx.fillText(
       this.catno,
-      this.position.X + this.length / 2,
-      this.position.Y + this.width / 2,
+      this.position.x + this.length / 2,
+      this.position.y + this.width / 2,
       this.length,
     );
 

--- a/src/track/track_manager.test.ts
+++ b/src/track/track_manager.test.ts
@@ -82,8 +82,8 @@ describe("add new track", () => {
 
     const track = manager.tracks[0];
 
-    expect(track.position.X).toBe(expectedX);
-    expect(track.position.Y).toBe(expectedY);
+    expect(track.position.x).toBe(expectedX);
+    expect(track.position.y).toBe(expectedY);
   });
 });
 


### PR DESCRIPTION
## What?
I deleted the coords.ts file and renamed Vector class's X and Y getters to lowercase x and y.

## Why?
Coords type was left over from PR #32.

## How?
Deleted coords.ts file and f2'd Vector.ts' X and Y getters.

## Testing?
All existing tests pass.

## Screenshots (optional)
n/a

## Anything else?
n/a